### PR TITLE
Navigation now differentiates civilian users and food pantry admins

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,6 +26,7 @@ function App(props) {
   const [username, setUsername] = useState("");
   const [token, setToken] = useState("");
   const [profile, setProfile] = useState("");
+  const [employeeOf, setEmployeeOf] = useState([]);
 
   /**
    * Log in, fetch profile of the user, and
@@ -47,6 +48,7 @@ function App(props) {
           setUsername(response.username);
           setToken(response.token);
           setProfile(response.profile);
+          setEmployeeOf(response.employee_of)
 
           // We only need to import toast in other components 
           // if we want to make a notification there.
@@ -66,10 +68,15 @@ function App(props) {
           setUsername("");
           setToken("");
           setProfile("");
+          setEmployeeOf([]);
 
           toast.info("👋 You are logged out. See you again!")
         }
       })
+  }
+  
+  const isAdmin = () => {
+    return employeeOf.length !== 0;
   }
 
   return (
@@ -93,6 +100,7 @@ function App(props) {
             <Navigation
               profile={profile}
               logout={logout}
+              isAdmin={isAdmin}
             />
             {/* A <Switch> looks through its children <Route>s and
                 renders the first one that matches the current URL. */}

--- a/frontend/src/components/Navigation.js
+++ b/frontend/src/components/Navigation.js
@@ -10,7 +10,7 @@ class Navigation extends Component {
     this.state = {
       message: "Welcome to the Welcome Page!",
       navbar4Admin: ["Manage Pantry", "Profile", "Logout"],
-      navbar4Customer: ["Cart", "Reservations", "Profile", "Logout"],
+      navbar4Customer: ["Search Food", "Profile", "Logout"],
       navbar4NotLoggedIn: ["Login", "Signup"],
     };
   }
@@ -28,7 +28,9 @@ class Navigation extends Component {
       case "Signup":
         return "/signup";
       case "Manage Pantry":
-        return "/pantry/"
+        return "/pantry"
+      case "Search Food":
+        return "/search-food"
       default:
         return "/";
     }
@@ -62,10 +64,14 @@ class Navigation extends Component {
     let navbarContent;
     navbarContent = this.state.navbar4NotLoggedIn;
     const { profile } = this.props;
-    if (profile) {
+    if (this.props.isAdmin()) {
       navbarContent = this.state.navbar4Admin;
     } else {
-      navbarContent = this.state.navbar4NotLoggedIn;
+      if (profile) {
+        navbarContent = this.state.navbar4Customer;
+      } else {
+        navbarContent = this.state.navbar4NotLoggedIn;
+      }
     }
 
     return (


### PR DESCRIPTION
Fixes #

**How to Test**
1. On initial load, navigation should look like below:
![image](https://user-images.githubusercontent.com/13430641/112595111-f69e8100-8dd7-11eb-9a2e-4ead1e17cc96.png)
2. Login with a credential of food pantry admin, and navigation should look like below:
![image](https://user-images.githubusercontent.com/13430641/112595237-2057a800-8dd8-11eb-8034-f870bedcd296.png)
3. Login with a credential of civilian user, and navigation should look like below:
![image](https://user-images.githubusercontent.com/13430641/112595196-103fc880-8dd8-11eb-82e6-50d7f5a87a4d.png)

**Change Summary**
Navigation now differentiates civilian users and food pantry admins